### PR TITLE
entrypoint.shの修正

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
 
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 git config user.name "${GITHUB_USER:-vesrioning redash user}"
 git config user.email "${GITHUB_EMAIL:-redash-versioning-queries@users.noreply.github.com'}"
 


### PR DESCRIPTION
- entrypoint.shの実行エラーの修正です。
- `git config --global --add safe.directory "$GITHUB_WORKSPACE"` を追加したら成功するようになりました
- 個人リポジトリで動作確認をして下図のようにコミットされました。
![image](https://user-images.githubusercontent.com/42694487/229800562-50d5592a-42fc-46a1-8cbf-954a60dcfb19.png)
